### PR TITLE
Modified makefile to use go 1.23 rather than the sonic default

### DIFF
--- a/services/pkt-handler/Makefile
+++ b/services/pkt-handler/Makefile
@@ -1,8 +1,19 @@
+export GO_VERSION := 1.23.4
+export GO_ROOT := /usr/lib/go-1.23
+
 all: pkt-handler
 
 pkt-handler:
 	/usr/local/go/bin/go version
-	/usr/local/go/bin/go build -o pkt-handler
+
+	echo "Installing Go $(GO_VERSION)...";
+	cd /tmp
+	sudo wget https://go.dev/dl/go$(GO_VERSION).linux-$(CONFIGURED_ARCH).tar.gz
+	sudo tar -C /usr/lib -xzf go$(GO_VERSION).linux-${CONFIGURED_ARCH}.tar.gz
+	sudo mv -f -T /usr/lib/go $(GO_ROOT)
+	rm go$(GO_VERSION).linux-*.tar.gz;
+
+	$(GO_ROOT)/bin/go build -o pkt-handler
 
 install:
 	install -D ./pkt-handler $(DESTDIR)/usr/bin/pkt-handler


### PR DESCRIPTION
The pkt-handler for Alpine by default uses the default go version of from sonic-buildimage (1.19  now). Override that and use 1.23 just for this make.