### PR TITLE
Add a wait in lucius-libsai if the docker is not ready

### DIFF
--- a/src/libsai-grpc/Makefile
+++ b/src/libsai-grpc/Makefile
@@ -34,6 +34,15 @@ libsai.so: $(PROTO_OBJ) $(GRPC_OBJ) $(SAI_OBJ) $(ENTRYPOINT_OBJ)
 	g++ -fPIC -o libsai.so -shared $(ENTRYPOINT_OBJ) dataplane/proto/sai/*.o dataplane/standalone/sai/*.o -lglog -lprotobuf -lgrpc++ -I . -I external/com_github_opencomputeproject_sai -I external/com_github_opencomputeproject_sai/inc -I external/com_github_opencomputeproject_sai/experimental
 
 lucius-libsai-bookworm:
+# Wait for docker daemon to come up. Takes 30-45 seconds in trixie
+	@wait_for_docker=0; \
+	while [ $$wait_for_docker -lt 40 ]; do \
+		docker info >/dev/null 2>&1 && break; \
+		sleep 3; \
+		wait_for_docker=$$((wait_for_docker + 1)); \
+	done; \
+	echo "Wait  of $$((wait_for_docker * 3)) seconds for docker"; \
+
 	DOCKER_BUILDKIT=1 docker build . -f Dockerfile.saibuilder -t lemming-libsai:latest
 	docker create --name libsai-temp lemming-libsai:latest
 	docker cp libsai-temp:/build/libsai.so ./libsai.so


### PR DESCRIPTION
After some recent changes in the basic Sonic infra, the docker-in-docker build in lucius-libsai is not able to find the docker ready on time.  Added a wait for the docker daemon to come up for upto 120 seconds.  The changes are harmless because in the worst case, it adds a 2 minute delay in build.

```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

This is issue is often seen when the view is fresh and occasionally afterwards.  The wait time is usually between 20 to 50 seconds. 

### Test logs

```
make[2]: Entering directory '/sonic/platform/alpinevs/src/libsai-grpc'
Wait  of 24 seconds for docker <====
DOCKER_BUILDKIT=1 docker build . -f Dockerfile.saibuilder -t lemming-libsai:latest
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

```